### PR TITLE
Enable multi-modal document ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ This project demonstrates a simple Retrieval-Augmented Generation (RAG) chatbot 
 
 The server now integrates optional web search via the [Serper](https://serper.dev) API. Set the `SERPER_API_KEY` environment variable before starting the server to enable this feature.
 
-## Uploading PDFs
+The RAG engine can now index text extracted from common image, audio and video formats using Tesseract OCR and Whisper. Ensure the appropriate dependencies are installed for best results.
+
+## Uploading Files
 
 1. Start the Jaseci server with `server.jac`.
 2. Launch the Streamlit app using `app.jac`.
-3. Use the *Upload PDF* widget to select one or more PDF files. The files are sent to the back‑end and stored under the `docs/` directory. The RAG engine indexes them immediately so future questions can reference their content.
+3. Use the *Upload File* widget to select PDFs, images, audio or video files. The files are sent to the back‑end and stored under the `docs/` directory. The RAG engine indexes them immediately so future questions can reference their content.
 

--- a/app.jac
+++ b/app.jac
@@ -11,11 +11,11 @@ def bootstrap_frontend(token: str) {
         st.session_state.messages = [];
     }
 
-    uploaded_file = st.file_uploader('Upload PDF');
+    uploaded_file = st.file_uploader('Upload File', type=['pdf','png','jpg','jpeg','mp3','wav','mp4','mov','avi']);
     if uploaded_file {
         file_b64 = base64.b64encode(uploaded_file.read()).decode('utf-8');
         response = requests.post(
-            "http://localhost:8000/walker/upload_pdf",
+            "http://localhost:8000/walker/upload_file",
             json={"file_name": uploaded_file.name, "file_data": file_b64},
             headers={"Authorization": f"Bearer {token}"}
         );

--- a/rag.jac
+++ b/rag.jac
@@ -4,6 +4,10 @@ import from langchain_text_splitters {RecursiveCharacterTextSplitter}
 import from langchain.schema.document {Document}
 import from langchain_openai {OpenAIEmbeddings}
 import from langchain_community.vectorstores.chroma {Chroma}
+import from PIL {Image};
+import pytesseract;
+import whisper;
+import from moviepy.editor {VideoFileClip};
 
 
 obj RagEngine {
@@ -28,8 +32,29 @@ obj RagEngine {
     }
 
     def load_document(file_path: str) {
-        loader = PyPDFLoader(file_path);
-        return loader.load();
+        ext = os.path.splitext(file_path)[1].lower();
+        if ext == '.pdf' {
+            loader = PyPDFLoader(file_path);
+            return loader.load();
+        } else if ext in ['.png', '.jpg', '.jpeg'] {
+            text = pytesseract.image_to_string(Image.open(file_path));
+            return [Document(page_content=text, metadata={'source': file_path})];
+        } else if ext in ['.mp3', '.wav'] {
+            model = whisper.load_model('base');
+            result = model.transcribe(file_path);
+            text = result.get('text', '');
+            return [Document(page_content=text, metadata={'source': file_path})];
+        } else if ext in ['.mp4', '.mov', '.avi'] {
+            clip = VideoFileClip(file_path);
+            audio_path = f"{file_path}.wav";
+            clip.audio.write_audiofile(audio_path);
+            model = whisper.load_model('base');
+            result = model.transcribe(audio_path);
+            text = result.get('text', '');
+            os.remove(audio_path);
+            return [Document(page_content=text, metadata={'source': file_path})];
+        }
+        return [];
     }
 
     def add_file(file_path: str) {

--- a/server.jac
+++ b/server.jac
@@ -76,7 +76,7 @@ walker interact {
     }
 }
 
-walker upload_pdf {
+walker upload_file {
     has file_name: str;
     has file_data: str;
 


### PR DESCRIPTION
## Summary
- extend RAG engine to load images, audio, and video
- rename upload walker and update UI
- document multi-modal support in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867c3a95ec0832383e40529fe61f931