### PR TITLE
Update media upload flow

### DIFF
--- a/app.jac
+++ b/app.jac
@@ -66,12 +66,14 @@ def bootstrap_frontend(token: str) {
         if response.status_code == 200 {
             res = response.json();
             
-            # Handle different response types
+            # Handle analysis results only when provided
             if endpoint in ['analyze_image', 'analyze_video'] {
                 msg = res["reports"][0].get("description") or res["reports"][0].get("summary");
-                file_type_name = "image" if endpoint == 'analyze_image' else "video";
-                analysis_message = f"I've analyzed your {file_type_name}: {msg}. Feel free to ask me any questions about it!";
-                st.session_state.messages.append({"role": "assistant", "content": analysis_message});
+                if msg {
+                    file_type_name = "image" if endpoint == 'analyze_image' else "video";
+                    analysis_message = f"I've analyzed your {file_type_name}: {msg}. Feel free to ask me any questions about it!";
+                    st.session_state.messages.append({"role": "assistant", "content": analysis_message});
+                }
             }
             
             st.success(success_msg);

--- a/server.jac
+++ b/server.jac
@@ -115,14 +115,15 @@ walker analyze_image {
             f.write(data);
         }
         img = Image(file_path);
-        text = self.message if self.message else "Describe the image content.";
-        desc = here.chat_with_image(img, text);
-        
-        # Add to chat history as a system message about the uploaded image
-        context_msg = f"User uploaded an image '{self.file_name}'. Analysis: {desc}";
-        here.chat_history.append({"role": "system", "content": context_msg});
-        
+
         if self.message {
+            text = self.message;
+            desc = here.chat_with_image(img, text);
+
+            # Add to chat history with the analysis result
+            context_msg = f"User uploaded an image '{self.file_name}'. Analysis: {desc}";
+            here.chat_history.append({"role": "system", "content": context_msg});
+
             here.chat_history.append({"role": "user", "content": self.message});
             response = here.chat_with_image(
                 img=img,
@@ -132,7 +133,10 @@ walker analyze_image {
             here.chat_history.append({"role": "assistant", "content": response});
             report {"description": desc, "response": response};
         } else {
-            report {"description": desc};
+            # Only record that an image was uploaded
+            context_msg = f"User uploaded an image '{self.file_name}'.";
+            here.chat_history.append({"role": "system", "content": context_msg});
+            report {"status": "image uploaded"};
         }
     }
 }
@@ -161,14 +165,15 @@ walker analyze_video {
             f.write(data);
         }
         video = Video(file_path, 1);
-        text = self.message if self.message else "Summarize the video content.";
-        summary = here.chat_with_video(video, text);
-        
-        # Add to chat history as a system message about the uploaded video
-        context_msg = f"User uploaded a video '{self.file_name}'. Summary: {summary}";
-        here.chat_history.append({"role": "system", "content": context_msg});
-        
+
         if self.message {
+            text = self.message;
+            summary = here.chat_with_video(video, text);
+
+            # Add to chat history with the summary result
+            context_msg = f"User uploaded a video '{self.file_name}'. Summary: {summary}";
+            here.chat_history.append({"role": "system", "content": context_msg});
+
             here.chat_history.append({"role": "user", "content": self.message});
             response = here.chat_with_video(
                 video=video,
@@ -178,7 +183,10 @@ walker analyze_video {
             here.chat_history.append({"role": "assistant", "content": response});
             report {"summary": summary, "response": response};
         } else {
-            report {"summary": summary};
+            # Only record that a video was uploaded
+            context_msg = f"User uploaded a video '{self.file_name}'.";
+            here.chat_history.append({"role": "system", "content": context_msg});
+            report {"status": "video uploaded"};
         }
     }
 }


### PR DESCRIPTION
## Summary
- only analyze images/videos when a message is included
- add conditional display of analysis results in frontend

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6874e0c416088323be4e3c1f19ddf2c0